### PR TITLE
`fusv-disable` & `fusv-enable` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ Returns an object with `unused` and `total`. `unused` has the array of unused va
 
 Array of strings of the variables to ignore, e.g. `['$my-var', '$my-second-var']`
 
+## Disable & enable
+
+Disable or enable `fusv` with the `fusv-disable` and `fusv-enable` comments:
+
+```scss
+$used-variable-1: #666;
+
+// fusv-disable
+$unused-variable: #coffee;
+// fusv-enable
+
+$used-variable-2: #ace;
+```
+
 ## Notes
 
 * The tool's logic is pretty "dumb"; if you use the same name for a variable in different files or namespaces,

--- a/lib/parse-variable.js
+++ b/lib/parse-variable.js
@@ -2,6 +2,8 @@
 
 const { parse: scssParse } = require('postcss-scss');
 const Declaration = require('postcss/lib/declaration');
+const Comment = require('postcss/lib/comment');
+let fusvEnabled = true;
 
 function parseNodes(nodes, variables, ignoreList) {
     for (let i = 0, len = nodes.length; i < len; i++) {
@@ -10,7 +12,17 @@ function parseNodes(nodes, variables, ignoreList) {
 }
 
 function findVars(node, result, ignoreList) {
-    if (node instanceof Declaration && node.prop.charAt(0) === '$' && !ignoreList.includes(node.prop)) {
+    if (node instanceof Comment) {
+        if (node.raws.text === 'fusv-enable') {
+            fusvEnabled = true;
+        } else if (node.raws.text === 'fusv-disable') {
+            fusvEnabled = false;
+        }
+
+        return;
+    }
+
+    if (node instanceof Declaration && node.prop.charAt(0) === '$' && !ignoreList.includes(node.prop) && fusvEnabled === true) {
         result.push(node.prop);
 
         return;

--- a/lib/parse-variable.js
+++ b/lib/parse-variable.js
@@ -13,16 +13,12 @@ function parseNodes(nodes, variables, ignoreList) {
 
 function findVars(node, result, ignoreList) {
     if (node instanceof Comment) {
-        if (node.raws.text === 'fusv-enable') {
-            fusvEnabled = true;
-        } else if (node.raws.text === 'fusv-disable') {
-            fusvEnabled = false;
-        }
+        parseComment(node);
 
         return;
     }
 
-    if (node instanceof Declaration && node.prop.charAt(0) === '$' && !ignoreList.includes(node.prop) && fusvEnabled === true) {
+    if (node instanceof Declaration && node.prop.charAt(0) === '$' && !ignoreList.includes(node.prop) && fusvEnabled) {
         result.push(node.prop);
 
         return;
@@ -30,6 +26,14 @@ function findVars(node, result, ignoreList) {
 
     if (node.nodes) {
         parseNodes(node.nodes, result, ignoreList);
+    }
+}
+
+function parseComment(node) {
+    if (node.raws.text === 'fusv-enable') {
+        fusvEnabled = true;
+    } else if (node.raws.text === 'fusv-disable') {
+        fusvEnabled = false;
     }
 }
 

--- a/tests/_variables.scss
+++ b/tests/_variables.scss
@@ -11,3 +11,9 @@ $black-lightest: #222;
 
 // ignored
 $ignored-variable: #ace;
+
+  // fusv-disable
+$disabled-variable: #bada55;
+// fusv-enable
+
+$enabled-variable: #b000b5;

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -8,7 +8,8 @@ const expectedUnused = [
     '$unused',
     '$black',
     '$nestedVar',
-    '$nestNestedVar'
+    '$nestNestedVar',
+    '$enabled-variable'
 ];
 
 const ignore = ['$ignored-variable'];


### PR DESCRIPTION
Ignore variables with comments. We'll probably need this if we want to continue with https://github.com/twbs/bootstrap/pull/29348. I've also tested this with Bootstraps' `v5-colors-shades-tints` branch.