### PR TITLE
feat: display tracking information about unused variables

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,15 +27,21 @@ function main(args) {
         console.log(`Finding unused variables in "${chalk.cyan.bold(dir)}"...`);
 
         // eslint-disable-next-line unicorn/no-array-callback-reference
-        const unusedVars = fusv.find(dir, { ignore });
+        const unusedVarsInfo = fusv.find(dir, { ignore });
 
-        console.log(`${chalk.cyan.bold(unusedVars.total)} total variables.`);
+        console.log(`${chalk.cyan.bold(unusedVarsInfo.total)} total variables.`);
 
-        unusedVars.unused.forEach(unusedVar => {
-            console.log(`Variable ${chalk.bold(unusedVar)} is not being used!`);
+        let currentFile = '';
+        unusedVarsInfo.unused.forEach(unusedVarInfo => {
+            if (currentFile !== unusedVarInfo.file) {
+                currentFile = unusedVarInfo.file;
+                console.log('\n\u001B[4m' + currentFile + '\u001B[0m');
+            }
+
+            console.log(` ${unusedVarInfo.lineInOwnFile}:${unusedVarInfo.column}\tVariable ${chalk.bold(unusedVarInfo.name)} is not being used!`);
         });
 
-        unusedList = unusedList.concat(unusedVars.unused);
+        unusedList = unusedList.concat(unusedVarsInfo.unused);
     });
 
     if (unusedList.length === 0) {

--- a/lib/parse-variable.js
+++ b/lib/parse-variable.js
@@ -11,6 +11,14 @@ function parseNodes(nodes, variables, ignoreList) {
     }
 }
 
+function isUnignoredVariable(node, ignoreList) {
+    if (node instanceof Declaration && node.prop.startsWith('$') && !ignoreList.includes(node.prop) && fusvEnabled) {
+        return true;
+    }
+
+    return false;
+}
+
 function findVars(node, result, ignoreList) {
     if (node instanceof Comment) {
         parseComment(node);
@@ -18,8 +26,13 @@ function findVars(node, result, ignoreList) {
         return;
     }
 
-    if (node instanceof Declaration && node.prop.startsWith('$') && !ignoreList.includes(node.prop) && fusvEnabled) {
-        result.push(node.prop);
+    if (isUnignoredVariable(node, ignoreList)) {
+        const nodeInfo = {
+            lineInAllFiles: node.source.start.line,
+            column: node.source.start.column,
+            name: node.prop
+        };
+        result.push(nodeInfo);
 
         return;
     }

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const app = express();
+
+app.get('/', (req, res) => {
+    res.send('Hello World!');
+});
+
+app.listen(3000, () => {
+    console.log('Listening on port 3000!');
+});

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -9,7 +9,11 @@ const expectedUnused = [
     '$black',
     '$nestedVar',
     '$nestNestedVar',
-    '$enabled-variable'
+    '$enabled-variable',
+    '$c',
+    '$d',
+    '$e',
+    '$f'
 ];
 
 const ignore = ['$ignored-variable'];


### PR DESCRIPTION
Unused variables are grouped per containig files and displayed with line
and column information. Files are displayed relatively to working
directory

fix(app.js): Fixed file according to xo linting rules

feat: print enhanced information of unused variable

line and column of unused variable with respect to all files of one
regarded directory, i.e., within concatenation of all those files, are
printed

fix: line Info of variable now gets displayed per containing file

fix(index.js): use object destructing for lineCountCumulated

fix(tests): adjusted expected values in integration.js

fix: unused variables are grouped per containing file

style(cli.js): applied fixes recarding to linter report

style(index.js): removed old comment

feat: display path of files containing unused variables relatively

fix: added newline to before files containing UVs are displayed

fix(integration.js): removed unneccessery output