### PR TITLE
feat: display tracking information about unused variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,25 @@ let unused = fusv.find('scss')
 // Array of unused variables
 console.log(unused.unused);
 // ['$foo', '$bar', '$imunused']
+console.log(unused.unusedOrigin);
+// [
+//  {
+//      name: '$foo',
+//      column: x_1,
+//      line: y_2,
+//      file 'scss/dir1/dir2/foo.scss'
+//  },
+//  {
+//      name: '$bar',
+//      column: x_2,
+//      line: y_2
+//      file 'scss/bar.scss'
+//  }
+//]
 console.log(unused.total);
-// Total number of variables in the files
+// Total number of variables in the files in directory 'scss'
+console.log(unused.totalUnused);
+// Number of unused variables in the files in directory 'scss'
 
 // ignoring variables
 const ignoredVars = ['$my-var', '$my-second-var']
@@ -44,7 +61,13 @@ unused = fusv.find('scss', { ignore: ignoredVars })
 * `dir`: string
 * `options`: optional options Object
 
-Returns an object with `unused` and `total`. `unused` has the array of unused variables and `total` has the sum of all variables in the files (unused and used ones).
+Returns an object with `unusedOrigin`, `unused`, `totalUnused` and`total`.
+
+* `unusedOrigin` is an array carrying objects containing unused sass variables and their origin,
+Information included are the `name` of the variable as well as the `line` and `column` of the variable in their originating `file`,
+* `unused` is an of array of unused variables without further information,
+* `totalUnused` has the sum of all unused variables of all examined files in given `dir`,
+*  and `total` has the sum of all variables of all examined files in given `dir` (unused and used ones).
 
 #### options.ignore
 

--- a/cli.js
+++ b/cli.js
@@ -30,13 +30,25 @@ function main(args) {
         const unusedVars = fusv.find(dir, { ignore });
 
         console.log(`${chalk.cyan.bold(unusedVars.total)} total variables.`);
+        console.log(`${chalk.cyan.bold(unusedVars.totalUnusedVars)} total unused variables.`);
 
-        unusedVars.unused.forEach(unusedVar => {
-            console.log(`Variable ${chalk.bold(unusedVar)} is not being used!`);
+        let currentFile = '';
+        const currentDirectory = process.cwd();
+        unusedVars.unusedInfo.forEach(unusedVar => {
+            if (currentFile !== unusedVar.file) {
+                currentFile = unusedVar.file;
+                const fileRelativePath = path.relative(currentDirectory, currentFile);
+                console.log(`\n${chalk.underline(fileRelativePath)}`);
+            }
+
+            console.log(
+                ` ${unusedVar.line}:${unusedVar.column}\t` +
+                `Variable ${chalk.bold(unusedVar.name)} is not being used!`
+            );
         });
 
         // eslint-disable-next-line unicorn/prefer-spread
-        unusedList = unusedList.concat(unusedVars.unused);
+        unusedList = unusedList.concat(unusedVars.unusedInfo);
     });
 
     if (unusedList.length === 0) {

--- a/lib/parse-variable.js
+++ b/lib/parse-variable.js
@@ -5,13 +5,13 @@ const Declaration = require('postcss/lib/declaration');
 const Comment = require('postcss/lib/comment');
 let fusvEnabled = true;
 
-function parseNodes(nodes, variables, ignoreList) {
+function parseNodes(nodes, variables, ignoreList, file = '') {
     for (const node of nodes) {
-        findVars(node, variables, ignoreList);
+        findVars(node, variables, ignoreList, file);
     }
 }
 
-function findVars(node, result, ignoreList) {
+function findVars(node, result, ignoreList, file = '') {
     if (node instanceof Comment) {
         parseComment(node);
 
@@ -19,13 +19,18 @@ function findVars(node, result, ignoreList) {
     }
 
     if (node instanceof Declaration && node.prop.startsWith('$') && !ignoreList.includes(node.prop) && fusvEnabled) {
-        result.push(node.prop);
+        result.push({
+            name: node.prop,
+            line: node.source.start.line,
+            column: node.source.start.column,
+            file
+        });
 
         return;
     }
 
     if (node.nodes) {
-        parseNodes(node.nodes, result, ignoreList);
+        parseNodes(node.nodes, result, ignoreList, file);
     }
 }
 
@@ -37,11 +42,11 @@ function parseComment(node) {
     }
 }
 
-function parse(scssString, ignoreList) {
+function parse(scssString, ignoreList, file = '') {
     const parsedScss = scssParse(scssString);
     const variables = [];
 
-    parseNodes(parsedScss.nodes, variables, ignoreList);
+    parseNodes(parsedScss.nodes, variables, ignoreList, file);
     return variables;
 }
 


### PR DESCRIPTION
**This is a feature and not a breaking change**

Unused variables are grouped per containig files and displayed with line
and column information. Files are displayed relatively to working
directory. In addition to total amount of variables, amount of unused
variables gets also displayed.

This feature heavily incorporates ideas from PR #124.
Co-Authored-By: Daniel <50356015+danny007in@users.noreply.github.com>
